### PR TITLE
Atualiza método para nova versão do Ruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ Example Workflow
 ----------------
 
     scorm create mypackage        # Create a new package skeleton
-    cd mypackage                  # 
+    cd mypackage                  #
     scorm bundle                  # Create .zip file from current directory
     scorm check mypackage.zip     # Verify that the package is valid SCORM
     scorm extract mypackage.zip   # Extract the mypackage.zip package
-    
+
 
 Installation
 ------------
@@ -37,7 +37,7 @@ To use the SCORM gem as a library in your application to extract and read
 SCORM files you can simply require the 'scorm/package' file.
 
     require 'scorm/package'
-    
+
     Scorm::Package.open('mypackage.zip') do |pkg|
       # Read stuff from the package...
       puts pkg.manifest.identifier
@@ -46,7 +46,7 @@ SCORM files you can simply require the 'scorm/package' file.
       pkg.manifest.resources.each do |resource|
         puts resource.href
         puts resource.scorm_type
-        if pkg.exists?(resource.files.first)
+        if pkg.exist?(resource.files.first)
           puts resource.files.first
           puts pkg.file(resource.files.first)
         end
@@ -56,7 +56,7 @@ SCORM files you can simply require the 'scorm/package' file.
 
 See the RDOC documentation for more info about what you can read from the
 package manifest.
-    
+
 
 About
 -----

--- a/lib/scorm.rb
+++ b/lib/scorm.rb
@@ -1,5 +1,5 @@
 module Scorm
-  VERSION = '1.0.2'
+  VERSION = '2.0.0'
 end
 
 require 'scorm/package'

--- a/lib/scorm/command.rb
+++ b/lib/scorm/command.rb
@@ -8,7 +8,7 @@ module Scorm
     class CommandFailed  < RuntimeError; end
 
     class << self
-      
+
       def error(msg)
         STDERR.puts(msg)
         exit 1

--- a/lib/scorm/commands/base.rb
+++ b/lib/scorm/commands/base.rb
@@ -4,12 +4,12 @@ module Scorm::Command
   class Base
     attr_accessor :args
     attr_reader :autodetected_package
-    
+
     def initialize(args)
       @args = args
       @autodetected_package = false
     end
-    
+
     def display(msg, newline=true)
       if newline
         puts(msg)

--- a/lib/scorm/commands/bundle.rb
+++ b/lib/scorm/commands/bundle.rb
@@ -5,9 +5,9 @@ module Scorm::Command
       unless File.exist?(File.join(File.expand_path(name), 'imsmanifest.xml'))
         raise(CommandFailed, "Invalid package, didn't find any imsmanifest.xml file.")
       end
-      
+
       outname = File.basename(File.expand_path(name)) + '.zip'
-      
+
       require 'zip'
       Zip::File.open(outname, Zip::File::CREATE) do |zipfile|
         Scorm::Package.open(name) do |pkg|
@@ -22,7 +22,7 @@ module Scorm::Command
           end
         end
       end
-      
+
       display "Created new SCORM package \"#{outname}\"."
     end
   end

--- a/lib/scorm/commands/check.rb
+++ b/lib/scorm/commands/check.rb
@@ -12,7 +12,7 @@ module Scorm::Command
         display ""
         display "== Manifest =="
         Scorm::Manifest::MANIFEST_FILES.each do |file|
-         if pkg.exists?(file)
+         if pkg.exist?(file)
            display "#{file} -> OK"
           else
             display "#{file} -> Missing"
@@ -32,7 +32,7 @@ module Scorm::Command
         pkg.manifest.resources.each do |resource|
           display "#{resource.href} (#{resource.type}, #{resource.scorm_type}):"
           resource.files.each do |file|
-            if pkg.exists?(file)
+            if pkg.exist?(file)
               display "  - #{file} -> OK"
             else
               display "  - #{file} -> Missing"

--- a/lib/scorm/datatypes.rb
+++ b/lib/scorm/datatypes.rb
@@ -1,11 +1,11 @@
 module Scorm
   module Datatypes
-    
+
     class Timeinterval
       def initialize(seconds)
         @sec = seconds
       end
-      
+
       def self.parse(str)
         case str
         when /(\d{2,4}):(\d{2}):(\d{2})/
@@ -34,15 +34,15 @@ module Scorm
         second = second || 0
         self.new((year*31557600) + (month*2629800) + (day*86400) + (hour*3600) + (minute*60) + second)
       end
-      
+
       def to_i
         @sec.to_i
       end
-      
+
       def to_f
         @sec.to_f
       end
-      
+
       def to_s
         sec = self.to_i
         hours = (sec/60/60).to_i
@@ -52,6 +52,6 @@ module Scorm
         return "#{hours}:#{min}:#{sec}"
       end
     end
-    
+
   end
 end

--- a/lib/scorm/manifest.rb
+++ b/lib/scorm/manifest.rb
@@ -5,25 +5,25 @@ require 'scorm/resource'
 
 module Scorm
   class Manifest
-    
+
     # Versions of the SCORM standard that is supported when running in
     # strict mode. When not running in strict mode, the library will not
     # care about the version specified in the package manifest and will
     # simply try its best to parse the information that it finds.
     SUPPORTED_VERSIONS = ['2004 3rd Edition', 'CAM 1.3', '1.2']
-    
+
     # List of XML and XML Schema files that are part of the manifest for
     # the package.
     MANIFEST_FILES = %w(imsmanifest.xml adlcp_rootv1p2.xsd ims_xml.xsd
        imscp_rootv1p1p2.xsd imsmd_rootv1p2p1.xsd)
-    
+
     # Files that might be present in a package, but that should not be
     # interprested as resources. All files starting with a "." (i.e. hidden
     # files) is also implicitly included in this list.
     RESOURCES_BLACKLIST = [
       '__MACOSX', 'desktop.ini', 'Thumbs.db'
     ].concat(MANIFEST_FILES)
-    
+
     attr_accessor :identifier
     attr_accessor :metadata
     attr_accessor :organizations
@@ -32,18 +32,18 @@ module Scorm
     attr_accessor :base_url
     attr_accessor :schema
     attr_accessor :schema_version
-  
+
     def initialize(package, manifest_data)
       @xmldoc = REXML::Document.new(manifest_data)
-    
+
       @package = package
       @metadata = Scorm::Metadata.new
       @organizations = Hash.new
       @resources = Hash.new
-      
+
       # Manifest identifier
       @identifier = @xmldoc.root.attribute('identifier').to_s
-    
+
       # Read metadata
       if metadata_el = REXML::XPath.first(@xmldoc.root, '/manifest/metadata')
         # Read <schema> and <schemaversion>
@@ -51,13 +51,13 @@ module Scorm
         schemaversion_el = REXML::XPath.first(metadata_el, 'schemaversion')
         @schema = schema_el.text.to_s unless schema_el.nil?
         @schema_version = schemaversion_el.text.to_s unless schemaversion_el.nil?
-        
+
         if @package.options[:strict]
           if (@schema != 'ADL SCORM') || (!SUPPORTED_VERSIONS.include?(@schema_version))
             raise InvalidManifest, "Sorry, unsupported SCORM-version (#{schema_el.text.to_s} #{schemaversion_el.text.to_s}), try turning strict parsing off."
           end
         end
-      
+
         # Find a <lom> element...
         lom_el = nil
         if adlcp_location = REXML::XPath.first(metadata_el, 'adlcp:location')
@@ -73,13 +73,13 @@ module Scorm
           lom_el = REXML::XPath.first(metadata_el, 'lom') ||
                    REXML::XPath.first(metadata_el, 'lom:lom')
         end
-      
+
         # Read lom metadata
         if lom_el
           @metadata = Scorm::Metadata.from_xml(lom_el)
         end
       end
-    
+
       # Read organizations
       if organizations_el = REXML::XPath.first(@xmldoc.root, '/manifest/organizations')
         default_organization_id = organizations_el.attribute('default').to_s
@@ -93,13 +93,13 @@ module Scorm
       else
         raise InvalidManifest, 'Missing organizations element.'
       end
-    
+
       # Read resources
       REXML::XPath.each(@xmldoc.root, '/manifest/resources/resource') do |el|
         res = Scorm::Resource.from_xml(el)
         @resources[res.id] = res
       end
-      
+
       # Read additional resources as assets (this is a fix for packages that
       # don't correctly specify all resource dependencies in the manifest).
       @package.files.each do |file|
@@ -108,19 +108,19 @@ module Scorm
         next if File.basename(file) =~ /^\./
         next unless self.resources(:with_file => file).empty?
         next unless self.resources(:href => file).empty?
-        
+
         res = Scorm::Resource.new(file, 'webcontent', 'asset', file, nil, [file])
         @resources[file] = res
       end
-    
+
       # Read (optional) base url for resources
       resources_el = REXML::XPath.first(@xmldoc.root, '/manifest/resources')
       @base_url = (resources_el.attribute('xml:base') || '').to_s
-    
+
       # Read sub-manifests
       #REXML::XPath.
     end
-  
+
     def resources(options = nil)
       if (options.nil?) || (!options.is_a?(Hash))
         @resources.values
@@ -144,7 +144,7 @@ module Scorm
         subset
       end
     end
-    
+
     def sco(item, attribute = nil)
       resource = self.resources(:id => item.resource_id).first
       resource = (resource && resource.scorm_type == 'sco') ? resource : nil

--- a/lib/scorm/metadata.rb
+++ b/lib/scorm/metadata.rb
@@ -1,11 +1,11 @@
 module Scorm
-  
-  # The +Metadata+ class holds meta data associated with a SCORM package in a 
-  # hash like structure. The +Metadata+ class reads a LOM (Learning Object 
+
+  # The +Metadata+ class holds meta data associated with a SCORM package in a
+  # hash like structure. The +Metadata+ class reads a LOM (Learning Object
   # Metadata) structure and stores the data in categories. A +Category+ can
   # contain any number of +DataElement+s. A +DataElement+ behaves just like
-  # a string but can contain the same value in many different languages, 
-  # accessed by the DataElement#value (or DataElement#to_s) method by 
+  # a string but can contain the same value in many different languages,
+  # accessed by the DataElement#value (or DataElement#to_s) method by
   # specifying the language code as the first argument.
   #
   # Ex.
@@ -16,7 +16,7 @@ module Scorm
   #   <tt>pkg.manifest.metadata.general.title.value('sv') -> 'Min kurs'</tt>
   #
   class Metadata < Hash
-    
+
     def self.from_xml(element)
       metadata = self.new
       element.elements.each do |category_el|
@@ -25,13 +25,13 @@ module Scorm
       end
       return metadata
     end
-    
+
     def method_missing(sym)
       self.fetch(sym.to_s, nil)
     end
-    
+
     class Category < Hash
-      
+
       def self.from_xml(element)
         category = Scorm::Metadata::Category.new
         element.elements.each do |data_el|
@@ -39,7 +39,7 @@ module Scorm
         end
         return category
       end
-      
+
       def method_missing(sym, *args)
         data_element = self.fetch(sym.to_s, nil)
         if data_element.is_a? DataElement
@@ -49,7 +49,7 @@ module Scorm
         end
       end
     end
-    
+
     class DataElement
       def initialize(value = '', default_lang = nil)
         if value.is_a? String
@@ -61,15 +61,15 @@ module Scorm
           @default_lang = default_lang || 'x-none'
         end
       end
-      
+
       def self.from_xml(element)
         if element.elements.size == 0
           return self.new(element.text.to_s)
-          
+
         elsif element.get_elements('value').size != 0
           value_el = element.get_elements('value').first
           return self.from_xml(value_el)
-          
+
         elsif element.get_elements('langstring').size != 0
           langstrings = Hash.new
           default_lang = nil
@@ -78,13 +78,13 @@ module Scorm
             langstrings[ls.attribute('xml:lang').to_s || 'x-none'] = ls.text.to_s
           end
           return self.new(langstrings, default_lang)
-          
+
         else
           return Category.from_xml(element)
-          
+
         end
       end
-      
+
       def value(lang = nil)
         if lang.nil?
           (@langstrings && @default_lang) ? @langstrings[@default_lang] : ''
@@ -92,7 +92,7 @@ module Scorm
           (@langstrings) ? @langstrings[lang] || '' : ''
         end
       end
-      
+
       alias :to_s :value
       alias :to_str :value
     end

--- a/lib/scorm/organization.rb
+++ b/lib/scorm/organization.rb
@@ -9,20 +9,20 @@
 module Scorm
   # The +Organization+ class holds data about the organization of a SCORM
   # package. An organization contains an id, title and any number of +items+.
-  # An +Item+ are (in most cases) the same thing as a SCO (Shareable Content 
+  # An +Item+ are (in most cases) the same thing as a SCO (Shareable Content
   # Object).
   class Organization
     attr_accessor :id
     attr_accessor :title
     attr_accessor :items
-    
+
     def initialize(id, title, items)
       raise InvalidManifest, 'missing organization id' if id.nil?
       @id = id.to_s
       @title = title.to_s
       @items = items
     end
-    
+
     def self.from_xml(element)
       id = element.attribute('identifier').to_s
       title = element.get_elements('title').first.text.to_s if element.get_elements('title').first
@@ -32,9 +32,9 @@ module Scorm
       end
       return self.new(id, title, items)
     end
-    
+
     # An item has an id, title, and (in some cases) a parent item. An item is
-    # associated with a resource, which in most cases is a SCO (Shareable 
+    # associated with a resource, which in most cases is a SCO (Shareable
     # Content Object) resource.
     class Item
       attr_accessor :id
@@ -46,7 +46,7 @@ module Scorm
       attr_accessor :time_limit_action
       attr_accessor :data_from_lms
       attr_accessor :completion_threshold
-      
+
       def initialize(id, title, isvisible = true, parameters = nil, resource_id = nil, children = nil)
         @id = id.to_s
         @title = title.to_s
@@ -55,7 +55,7 @@ module Scorm
         @resource_id = resource_id
         @children = children if children.is_a? Array
       end
-      
+
       def self.from_xml(element)
         item_id = element.attribute('identifier').to_s
         item_title = element.get_elements('title').first.text.to_s if element.get_elements('title').first

--- a/lib/scorm/package.rb
+++ b/lib/scorm/package.rb
@@ -74,14 +74,14 @@ module Scorm
           i = (i || 0) + 1
 
         # Make sure the generated path is unique.
-        end while File.exists?(@path)
+        end while File.exist?(@path)
       end
 
       # Extract the package
       extract!
 
       # Detect and read imsmanifest.xml
-      if exists?('imsmanifest.xml')
+      if exist?('imsmanifest.xml')
         @manifest = Manifest.new(self, file('imsmanifest.xml'))
       else
         raise InvalidPackage, "#{File.basename(@package)}: no imsmanifest.xml, maybe not SCORM compatible?"
@@ -112,7 +112,7 @@ module Scorm
 
     # Cleans up by deleting all extracted files. Called when an error occurs.
     def cleanup
-      FileUtils.rmtree(@path) if @options[:cleanup] && !@options[:dry_run] && @path && File.exists?(@path) && package?
+      FileUtils.rmtree(@path) if @options[:cleanup] && !@options[:dry_run] && @path && File.exist?(@path) && package?
     end
 
     # Extracts the content of the package to the course repository. This will be
@@ -134,7 +134,7 @@ module Scorm
       Zip::File::foreach(@package) do |entry|
         entry_path = File.join(@path, entry.name)
         entry_dir = File.dirname(entry_path)
-        FileUtils.mkdir_p(entry_dir) unless File.exists?(entry_dir)
+        FileUtils.mkdir_p(entry_dir) unless File.exist?(entry_dir)
         entry.extract(entry_path)
       end
     end
@@ -152,7 +152,7 @@ module Scorm
     # set to +true+ when opening the package the file will <em>not</em> be
     # extracted to the file system, but read directly into memory.
     def file(filename)
-      if File.exists?(@path)
+      if File.exist?(@path)
         File.read(path_to(filename))
       else
         Zip::File.foreach(@package) do |entry|
@@ -162,9 +162,9 @@ module Scorm
     end
 
     # Returns +true+ if the specified file (or directory) exists in the package.
-    def exists?(filename)
-      if File.exists?(@path)
-        File.exists?(path_to(filename))
+    def exist?(filename)
+      if File.exist?(@path)
+        File.exist?(path_to(filename))
       else
         Zip::File::foreach(@package) do |entry|
           return true if entry.name == filename

--- a/lib/scorm/package.rb
+++ b/lib/scorm/package.rb
@@ -8,7 +8,7 @@ require 'scorm/manifest'
 module Scorm
   class InvalidPackage < RuntimeError; end
   class InvalidManifest < InvalidPackage; end
-  
+
   class Package
     attr_accessor :name       # Name of the package.
     attr_accessor :manifest   # An instance of +Scorm::Manifest+.
@@ -16,25 +16,25 @@ module Scorm
     attr_accessor :repository # The directory to which the packages is extracted.
     attr_accessor :options    # The options hash supplied when opening the package.
     attr_accessor :package    # The file name of the package file.
-    
-    DEFAULT_LOAD_OPTIONS = { 
+
+    DEFAULT_LOAD_OPTIONS = {
       :strict => false,
-      :dry_run => false, 
+      :dry_run => false,
       :cleanup => true,
       :force_cleanup => false,
       :name => nil,
       :repository => nil
     }
-    
+
     def self.set_default_load_options(options = {})
       DEFAULT_LOAD_OPTIONS.merge!(options)
     end
-    
+
     def self.open(filename, options = {}, &block)
       Package.new(filename, options, &block)
     end
-    
-    # This method will load a SCORM package and extract its content to the 
+
+    # This method will load a SCORM package and extract its content to the
     # directory specified by the +:repository+ option. The manifest file will be
     # parsed and made available through the +manifest+ instance variable. This
     # method should be called with an associated block as it yields the opened
@@ -45,15 +45,15 @@ module Scorm
     #   :+strict+:     If +false+ the manifest will be parsed in a nicer way. Default: +true+.
     #   :+dry_run+:    If +true+ nothing will be written to the file system. Default: +false+.
     #   :+cleanup+:    If +false+ no cleanup will take place if an error occur. Default: +true+.
-    #   :+name+:       The name to use when extracting the package to the 
-    #                  repository. Default: will use the filename of the package 
+    #   :+name+:       The name to use when extracting the package to the
+    #                  repository. Default: will use the filename of the package
     #                  (minus the .zip extension).
     #   :+repository+: Path to the course repository. Default: the same directory as the package.
     #
     def initialize(filename, options = {}, &block)
       @options = DEFAULT_LOAD_OPTIONS.merge(options)
       @package = filename.respond_to?(:path) ? filename.path : filename
-      
+
       # Check if package is a directory or a file.
       if File.directory?(@package)
         @name = File.basename(@package)
@@ -64,73 +64,73 @@ module Scorm
         begin
           # Decide on a name for the package.
           @name = [(@options[:name] || File.basename(@package, File.extname(@package))), i].flatten.join
-      
+
           # Set the path for the extracted package.
           @repository = @options[:repository] || File.dirname(@package)
           @path = File.expand_path(File.join(@repository, @name))
-        
-          # First try is nil, subsequent tries sets and increments the value with 
+
+          # First try is nil, subsequent tries sets and increments the value with
           # one starting at zero.
           i = (i || 0) + 1
 
         # Make sure the generated path is unique.
         end while File.exists?(@path)
       end
-      
+
       # Extract the package
       extract!
-                                                        
+
       # Detect and read imsmanifest.xml
       if exists?('imsmanifest.xml')
         @manifest = Manifest.new(self, file('imsmanifest.xml'))
       else
         raise InvalidPackage, "#{File.basename(@package)}: no imsmanifest.xml, maybe not SCORM compatible?"
       end
-      
+
       # Yield to the caller.
       yield(self)
-      
+
       # Make sure the package is closed when the caller has finished reading it.
       self.close
 
-    # If an exception occur the package is auto-magically closed and any 
+    # If an exception occur the package is auto-magically closed and any
     # residual data deleted in a clean way.
     rescue Exception => e
       self.close
       self.cleanup
       raise e
     end
-    
+
     # Closes the package.
     def close
       @zipfile.close if @zipfile
-      
+
       # Make sure the extracted package is deleted if force_cleanup_on_close
       # is enabled.
       self.cleanup if @options[:force_cleanup_on_close]
     end
-    
+
     # Cleans up by deleting all extracted files. Called when an error occurs.
     def cleanup
       FileUtils.rmtree(@path) if @options[:cleanup] && !@options[:dry_run] && @path && File.exists?(@path) && package?
     end
-    
+
     # Extracts the content of the package to the course repository. This will be
     # done automatically when opening a package so this method will rarely be
     # used. If the +dry_run+ option was set to +true+ when the package was
     # opened nothing will happen. This behavior can be overridden with the
-    # +force+ parameter. 
+    # +force+ parameter.
     def extract!(force = false)
       return if @options[:dry_run] && !force
-      
+
       # If opening an already extracted package; do nothing.
       if not package?
         return
       end
-      
+
       # Create the path to the course
       FileUtils.mkdir_p(@path)
-      
+
       Zip::File::foreach(@package) do |entry|
         entry_path = File.join(@path, entry.name)
         entry_dir = File.dirname(entry_path)
@@ -138,14 +138,14 @@ module Scorm
         entry.extract(entry_path)
       end
     end
-    
+
     # This will only return +true+ if what was opened was an actual zip file.
     # It returns +false+ if what was opened was a filesystem directory.
     def package?
       return false if File.directory?(@package)
       return true
     end
-    
+
     # Reads a file from the package. If the file is not extracted yet (all files
     # are extracted by default when opening the package) it will be extracted
     # to the file system and its content returned. If the +dry_run+ option was
@@ -160,7 +160,7 @@ module Scorm
         end
       end
     end
-    
+
     # Returns +true+ if the specified file (or directory) exists in the package.
     def exists?(filename)
       if File.exists?(@path)
@@ -172,9 +172,9 @@ module Scorm
         false
       end
     end
-    
+
     # Computes the absolute path to a file in an extracted package given its
-    # relative path. The argument +relative+ can be used to get the path 
+    # relative path. The argument +relative+ can be used to get the path
     # relative to the course repository.
     #
     # Ex.
@@ -190,7 +190,7 @@ module Scorm
         File.join(@path, relative_filename)
       end
     end
-    
+
     # Returns an array with the paths to all the files in the package.
     def files
       if File.directory?(@package)

--- a/lib/scorm/resource.rb
+++ b/lib/scorm/resource.rb
@@ -1,5 +1,5 @@
 module Scorm
-  
+
   # A +Resource+ is a representation/description of an actual resource (image,
   # sco, pdf, etc...) in a SCORM package.
   class Resource
@@ -10,7 +10,7 @@ module Scorm
     attr_accessor :metadata
     attr_accessor :files
     attr_accessor :dependencies
-    
+
     def initialize(id, type, scorm_type, href = nil, metadata = nil, files = nil, dependencies = nil)
       raise InvalidManifest, 'Missing resource id' if id.nil?
       raise InvalidManifest, 'Missing resource type' if type.nil?
@@ -24,7 +24,7 @@ module Scorm
       @files = files || []
       @dependencies = dependencies || []
     end
-    
+
     def self.from_xml(element)
       metadata = nil
       files = []
@@ -35,10 +35,10 @@ module Scorm
       REXML::XPath.each(element, 'dependency') do |dep_el|
         dependencies << dep_el.attribute('identifierref').to_s
       end
-    
+
       res = self.new(
-        element.attribute('identifier'), 
-        element.attribute('type'), 
+        element.attribute('identifier'),
+        element.attribute('type'),
         element.attribute('scormType', 'adlcp') || element.attribute('scormtype', 'adlcp'),
         element.attribute('xml:base').to_s + element.attribute('href').to_s,
         metadata,

--- a/scorm.gemspec
+++ b/scorm.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'scorm'
-  s.version     = '1.0.2'
+  s.version     = '2.0.0'
   s.summary     = 'Ruby library for reading, extracting and generating SCORM files.'
   s.description = 'SCORM is a Ruby library for reading and extracting Shareable Content Object Reference Model (SCORM) files. SCORM is a standardized package format used mainly by e-learning software to help with the exchange of course material between systems in an interoperable way. This gem supports SCORM 1.2 and SCORM 2004.'
 
@@ -8,11 +8,11 @@ Gem::Specification.new do |s|
   s.email       = 'niklas.holmgren@mindset.se'
   s.homepage    = 'http://github.com/mindset/scorm/'
 
-  s.files         = Dir['README', 'LICENSE', 'bin/**/*', 'examples/**/*', 'skeleton/**/*', 'lib/**/{*,.[a-z]*}']
-  s.require_path  = 'lib'
+  s.files        = Dir['README', 'LICENSE', 'bin/**/*', 'examples/**/*', 'skeleton/**/*', 'lib/**/{*,.[a-z]*}']
+  s.require_path = 'lib'
 
-  s.bindir             = 'bin'
-  s.executables        = ['scorm']
+  s.bindir      = 'bin'
+  s.executables = ['scorm']
 
-  s.add_dependency('rubyzip',  '~> 1.1')
+  s.add_dependency('rubyzip',  '~> 2.3')
 end


### PR DESCRIPTION
### Atualiza sintaxe depreciada desde o Ruby `2.1`
> _[Referência da alteração.](https://stackoverflow.com/a/75353113/7346892)_

```ruby
# Método antigo (.exists)
File.exists?('xyz')

# Método novo (.exist)
File.exist?('xyz')
````